### PR TITLE
Fix invalid date format for IDIT field

### DIFF
--- a/.github/workflows/AVIMetaEdit_Checks.yml
+++ b/.github/workflows/AVIMetaEdit_Checks.yml
@@ -35,11 +35,10 @@ jobs:
       - name: Configure GUI
         run: |
           cd Project/QtCreator
-          export PATH=/usr/local/opt/qt@5/bin:$PATH
-          export QT_SELECT=qt5
-          ./prepare INCLUDEPATH+=/usr/local/include CONFIG+=c++11 -after QMAKE_MACOSX_DEPLOYMENT_TARGET=10.9
+          export PATH=/opt/homebrew/opt/qt@5/bin:$PATH
+          ./prepare CONFIG+=c++11 -after QMAKE_MACOSX_DEPLOYMENT_TARGET=10.9
       - name: Build GUI
         run: |
           cd Project/QtCreator
-          export PATH=/usr/local/opt/qt/bin:$PATH
+          export PATH=/opt/homebrew/opt/qt@5/bin:$PATH
           make

--- a/Source/GUI/Qt/GUI_Main_xxxx_DateDialog.cpp
+++ b/Source/GUI/Qt/GUI_Main_xxxx_DateDialog.cpp
@@ -29,6 +29,9 @@
 #include <QDesktopWidget>
 #include <QApplication>
 #include <QMessageBox>
+#include <iomanip>
+#include <sstream>
+#include <locale>
 #include <ctime>
 using namespace std;
 //---------------------------------------------------------------------------
@@ -233,9 +236,10 @@ void GUI_Main_xxxx_DateDialog::OnCalendar_Changed()
         Time.tm_wday=Calendar->selectedDate().dayOfWeek()==Qt::Sunday?0:Calendar->selectedDate().dayOfWeek();
         Time.tm_yday=Calendar->selectedDate().dayOfYear();
         Time.tm_isdst=-1;
-        QString Time_Q(asctime(&Time));
-        Time_Q.truncate(24);
-        TextEdit->setPlainText(Time_Q);
+        stringstream ss;
+        ss.imbue(std::locale("C"));
+        ss << put_time(&Time, "%a %b %d %H:%M:%S %Y");
+        TextEdit->setPlainText(QString().fromLatin1(ss.str().c_str()));
         return;
     }
     


### PR DESCRIPTION
On some platforms, asctime pad date with spaces instead of zeros